### PR TITLE
fix iterator usage

### DIFF
--- a/cpp/bench.cpp
+++ b/cpp/bench.cpp
@@ -6,15 +6,12 @@
 static void BM_Run(benchmark::State &state) {
   for (auto _ : state) {
     int res = run();
-#if defined(USE_ANKRL) // Fast map is somehow broken
-#else
     if (res != 58) {
       std::stringstream ss;
       ss << "Invalid result ";
       ss << res;
       throw std::runtime_error(ss.str());
     }
-#endif
   }
 }
 

--- a/cpp/part2.cpp
+++ b/cpp/part2.cpp
@@ -133,22 +133,20 @@ struct Calculator {
 
       // Not exposed to air
       if (containsA && containsB) {
-#ifdef USE_BTREE
-        // For some reason this is required with abseil's btree implementation.
-        it = sides.erase(it++);
-#else
+#if USE_ABSL_FLAT_SET
         sides.erase(it++);
+#else
+        it = sides.erase(it);
 #endif
         continue;
       }
 
       // Not exposed to lava
       if (!isLavaSide(side)) {
-#ifdef USE_BTREE
-        // For some reason this is required with abseil's btree implementation.
-        it = sides.erase(it++);
-#else
+#if USE_ABSL_FLAT_SET
         sides.erase(it++);
+#else
+        it = sides.erase(it);
 #endif
         continue;
       }

--- a/cpp/sets/dense.h
+++ b/cpp/sets/dense.h
@@ -11,9 +11,7 @@ struct Vec3Hash {
   using is_avalanching = void;
 
   [[nodiscard]] auto operator()(Vec3<T> const &vec) const noexcept -> uint64_t {
-    return ((ankerl::unordered_dense::detail::wyhash::hash(vec.x) ^
-             (ankerl::unordered_dense::detail::wyhash::hash(vec.y) << 1)) >> 1) ^
-           (ankerl::unordered_dense::detail::wyhash::hash(vec.z) << 1);
+    return ankerl::unordered_dense::detail::wyhash::hash(&vec, sizeof(vec));
   }
 };
 


### PR DESCRIPTION
I was looking for people using my map/set, and found your repository. Here is a fix to get the correct results :-)
The problem is that this is not allowed with most set implementations:

```cpp
sides.erase(it++);
```

since erase might invalidate all iterators, it's not allowed to use it afterwards. So the code in USE_BTREE

```cpp
it = sides.erase(it++);
```

is more correct, but the `++` is not necessary because it will be overwritten anyways. The version that works with any set, no matter if iterators are invalidated or not is this:

```cpp
it = sides.erase(it);
```

Only abseil does it differently: https://github.com/abseil/abseil-cpp/blob/20230125.0/absl/container/flat_hash_map.h#L228-L233